### PR TITLE
Travis CI config for VirtualAgc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: c
+
+services:
+  - docker
+
+before_install:
+  - docker build -t virtualagc .
+
+script:
+  - make all

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   - docker build -t virtualagc .
 
 script:
-  - make all
+  - make missions

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Jim Lawton
 
 RUN apt-get -y update
-RUN apt-get -y upgrade
+#RUN apt-get -y upgrade
 
 RUN apt-get -y install git
 RUN apt-get -y install build-essential


### PR DESCRIPTION
This change adds a Travis config file. This can be used to trigger CI builds on travis-ci.org. 

It also changes the Docker config to not upgrade packages from the distro baseline by default, to speed up the build.