### PR TITLE
#46: Correct clearing of CH13's TIME6 enable bit on T6RUPT

### DIFF
--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -1639,7 +1639,7 @@ agc_engine (agc_t * State)
             {
 	      State->InterruptRequests[1] = 1;
               // Triggering a T6RUPT disables T6 by clearing the CH13 bit
-              CpuWriteIO(State, 013, c(RegTIME6) & 037777);
+              CpuWriteIO(State, 013, State->InputChannel[013] & 037777);
             }
         }
       // Return, so as to account for the time occupied by updating the


### PR DESCRIPTION
Fixes a problem with #46. Channel 13 should be written with the masked contents of channel 13, *not* of TIME6...