### PR TITLE
yaAGC: Added a special case to DV (Dividend = 0, Divisor != 0)

### DIFF
--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -250,6 +250,10 @@
  *				can only be triggered by a ZOUT from DINC. TIME6
  *				only counts when enabled, and is disabled upon
  *				triggering T6RUPT.
+ *		09/08/16 MAS	Added a special case for DV -- when the dividend
+ *				is 0 and the divisor is not, the quotient and
+ *				remainder are both 0 with the sign matching the
+ *				dividend.
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,
  * or more particularly for the Apollo Guidance Computer (AGC) may be found at
@@ -2464,6 +2468,21 @@ agc_engine (agc_t * State)
 		  c (RegL) = SignExtend (*WhereWord);
 		}
 	      c (RegA) = SignExtend (Operand16);
+	    }
+	  else if (AbsA == 0 && AbsL == 0 && AbsK != 0)
+	    {
+	      // The divisor is 0 but the dividend is not. The quotient and
+	      // the remainder both receive 0 with the sign matching the dividend
+	      if (Dividend == 0)
+	        {
+	          c (RegA) = AGC_P0;
+	          c (RegL) = AGC_P0;
+	        }
+	      else
+	        {
+	          c (RegA) = SignExtend (AGC_M0);
+	          c (RegL) = SignExtend (AGC_M0);
+	        }
 	    }
 	  else
 	    {

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -2471,7 +2471,7 @@ agc_engine (agc_t * State)
 	    }
 	  else if (AbsA == 0 && AbsL == 0 && AbsK != 0)
 	    {
-	      // The divisor is 0 but the dividend is not. The quotient and
+	      // The dividend is 0 but the divisor is not. The quotient and
 	      // the remainder both receive 0 with the sign matching the dividend
 	      if (Dividend == 0)
 	        {


### PR DESCRIPTION
This changes agc_engine to behave similarly to the hardware sim in this particular case of divide. This has the potential to fix #52, as in isolated test cases, a requested 77777 gimbal angle triggers 401 alarms in yaAGC, but not in the hardware sim.

I've got no detailed analysis to suggest that this should be the case this time around... just the statement that this is the apparent current behavior of the hardware sim (which very well could be wrong. I don't trust my DV anywhere near enough to say with certainty that it is wired correctly). The divide case makes plentiful use of WHOMP, which isn't documented in AGC4 Memo *#*9 and makes control pulse analysis even more of a pain than in non-WHOMP-using DVs.

Somewhat even more frighteningly, this PR contains no changes to Validation, because no changes to Validation were required.... this results in a measurable behavior change for yaAGC but Validation can't tell the difference. Even though the DV checks are constructed straight from Smally. Yikes.

@indy91 or @eddievhfan1984, would you mind trying this out to see if the 401s are impacted at all? Thanks!