### PR TITLE
Correct (again) signs when dividing 0 by a nonzero number

### DIFF
--- a/Validation/ValidateDV.agc
+++ b/Validation/ValidateDV.agc
@@ -20,6 +20,136 @@
 # Purpose:	This is the part of the Validation program that validates
 #		just the DV instruction.
 # Mod history:	07/05/04 RSB.	Began.
+# 		09/11/16 MAS.	Added eight checks for 0 divided by a number
 		
 		INCR	ERRNUM
 		
+		# Check some corner corner cases discovered by NASSP
+
+		INCR	ERRSUB		#1
+		CA	TWO
+		TS	TEMPI
+		CA	ZEROES		# Check +0+0 / +2 = +0, +0
+		TS	L
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is +0
+		TCF	DVERR
+		TCF	DV1LCHK
+		TCF	DVERR
+		TCF	DVERR
+DV1LCHK		CCS	L 		# Check that L is +0
+		TCF	DVERR
+		TCF	DV2
+		TCF	DVERR
+		TCF	DVERR
+
+DV2		INCR	ERRSUB		#2
+		CA	NEGZERO		# Check that -0+0 / +2 = +0, +0
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is +0
+		TCF	DVERR
+		TCF	DV2LCHK
+		TCF	DVERR
+		TCF	DVERR
+DV2LCHK		CCS	L 		# Check that L is +0
+		TCF	DVERR
+		TCF	DV3
+		TCF	DVERR
+		TCF	DVERR
+
+DV3		INCR	ERRSUB		#3
+		CA	NEGZERO		# Check that +0-0 / +2 = -0, -0
+		TS	L
+		CA	ZEROES
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+DV3LCHK		CCS	L 		# Check that L is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+
+DV4		INCR	ERRSUB		#4
+		CA	NEGZERO		# Check that -0-0 / +2 = -0, -0
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+DV4LCHK		CCS	L 		# Check that L is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+
+DV5		CA	NEGTWO
+		TS	TEMPI
+		INCR	ERRSUB		#5
+		CA	ZEROES		# Check that +0+0 / -2 = -0, +0
+		TS	L
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+DV5LCHK		CCS	L 		# Check that L is +0
+		TCF	DVERR
+		TCF	DV6
+		TCF	DVERR
+		TCF	DVERR
+
+DV6		INCR	ERRSUB		#6
+		CA	NEGZERO		# Check that -0+0 / -2 = -0, +0
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+DV6LCHK		CCS	L 		# Check that L is +0
+		TCF	DVERR
+		TCF	DV7
+		TCF	DVERR
+		TCF	DVERR
+
+DV7		INCR	ERRSUB		#7
+		CA	NEGZERO		# Check that +0-0 / -2 = +0, -0
+		TS	L
+		CA	ZEROES
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is +0
+		TCF	DVERR
+		TCF	DV7LCHK
+		TCF	DVERR
+		TCF	DVERR
+DV7LCHK		CCS	L 		# Check that L is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+
+DV8		INCR	ERRSUB		#8
+		CA	NEGZERO		# Check that -0-0 / -2 = +0, -0
+		EXTEND
+		DV	TEMPI
+		CCS	A		# Check that A is +0
+		TCF	DVERR
+		TCF	DV8LCHK
+		TCF	DVERR
+		TCF	DVERR
+DV8LCHK		CCS	L 		# Check that L is -0
+		TCF	DVERR
+		TCF	DVERR
+		TCF	DVERR
+
+		TCF	+2
+DVERR		TC	ERRORDSP
+		CA	ZEROES
+		TS	ERRSUB
+

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -2471,18 +2471,12 @@ agc_engine (agc_t * State)
 	    }
 	  else if (AbsA == 0 && AbsL == 0 && AbsK != 0)
 	    {
-	      // The dividend is 0 but the divisor is not. The quotient and
-	      // the remainder both receive 0 with the sign matching the dividend
-	      if (Dividend == 0)
-	        {
-	          c (RegA) = AGC_P0;
-	          c (RegL) = AGC_P0;
-	        }
+	      // The dividend is 0 but the divisor is not. The standard DV sign
+	      // convention applies to A, and L remains unchanged.
+	      if ((040000 & c (RegL)) == (040000 & *WhereWord))
+	        c (RegA) = AGC_P0;
 	      else
-	        {
-	          c (RegA) = SignExtend (AGC_M0);
-	          c (RegL) = SignExtend (AGC_M0);
-	        }
+	        c (RegA) = SignExtend (AGC_M0);
 	    }
 	  else
 	    {


### PR DESCRIPTION
Welp... the control pulse study I did for #53 ended up being useful. Because despite showing the changes were correct in all the cases studied on that PR... it made me realize that they were wrong in some others that I hadn't looked at. Namely, when the dividend is 77777,00000, and when the divisor is negative.

Since I'm now pretty confident in the sim's correctness when dividing 0 by things, I put together a little table of all combinations of +0s, -0s, and divisors:

00000,00000 / p = 00000,00000
77777,00000 / p = 00000,00000
00000,77777 / p = 77777,77777
77777,77777 / p = 77777,77777

00000,00000 / n = 77777,00000
77777,00000 / n = 77777,00000
00000,77777 / n = 00000,77777
77777,77777 / n = 00000,77777

There's two things to take away from that:
1. L never changes, so I should just leave it alone
2. The sign of A follows standard rules. It's positive if the signs of L and the divisor match, and negative if they don't.

This changes the behavior to match those two points. @indy91, you're probably going to want to pull this one over.

Also, this has annoyed me enough that I'm going to put together Validation cases for all eight of the combinations listed above. I have a feeling that even after we have a complete self-check, Validation will remain useful as a bastion for corner cases and other differences not directly caught by it.