### PR TITLE
#26: Correct cycle count for multi-MCT instructions

### DIFF
--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -254,6 +254,8 @@
  *				is 0 and the divisor is not, the quotient and
  *				remainder are both 0 with the sign matching the
  *				dividend.
+ *		09/11/16 MAS	Applied Gergo's fix for multi-MCT instructions
+ *				taking a cycle longer than they should.
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,
  * or more particularly for the Apollo Guidance Computer (AGC) may be found at
@@ -1885,7 +1887,7 @@ agc_engine (agc_t * State)
       if (i)
 	{
 	  State->PendFlag = 1;
-	  State->PendDelay = i;
+	  State->PendDelay = i-1;
 	  return (0);
 	}
     }


### PR DESCRIPTION
This is Gergo "[Massive Camel](https://code.google.com/archive/p/virtualagc/issues/26)"'s fix for #26. I posted a description of what's happening on the issue.

@indy91, this will almost certainly make the 1201s and 1202s go away -- the total CPU load is going to be greatly reduced. I gotta say, it's pretty friggin awesome that this ended up mattering for something, though. Especially since it resulted in those particular alarms!