### PR TITLE
Night Watchman emulation in yaAGC

### DIFF
--- a/yaAGC/agc_cli.c
+++ b/yaAGC/agc_cli.c
@@ -34,6 +34,7 @@
   Reference:	http://www.ibiblio.org/apollo
   Mods:         11/30/08 OH.	Began rework
                 08/04/16 OH     Fixed the GPL statement and old user-id
+                09/30/16 MAS    Added the --inhibit-alarms option
  */
 
 #include <string.h>
@@ -89,6 +90,8 @@ static void CliShowUsage(void)
 "                  messages being received from the DEDA, but never to\n"
 "                  send any.  That lets \"yaAGC --debug-deda --deda-quiet\"\n"
 "                  to be used alongside yaAGS without conflict.\n"
+"--inhibit-alarms  Prevents the simulated hardware alarms (Night Watchman\n"
+"                  Rupt Lock, and TC Trap) from causing resets.\n"
 "--cfg=file        The name of a configuration file.  Presently, the\n"
 "                  configuration files is used only for --debug-dsky\n"
 "                  mode.  It would typically be the same configuration\n"
@@ -175,6 +178,7 @@ static void CliInitializeOptions(void)
 	  Options.debug_dsky = 0;
 	  Options.debug_deda = 0;
 	  Options.deda_quiet = 0;
+	  Options.inhibit_alarms = 0;
 	  Options.quiet = 0;
 	  Options.fullname = 0;
 	  Options.debug = 1;
@@ -219,6 +223,7 @@ static int CliProcessArgument(char* token)
 	else if (!strcmp (token, "-debug-dsky")) Options.debug_dsky = 1;
 	else if (!strcmp (token, "-debug-deda")) Options.debug_deda = 1;
 	else if (!strcmp (token, "-deda-quiet")) Options.deda_quiet = 1;
+	else if (!strcmp (token, "-inhibit-alarms")) Options.inhibit_alarms = 1;
 	else if (!strcmp (token, "-cdu-log")) Options.cdu_log = CduLog;
 	else if (!strncmp (token, "-cfg=", 5)) Options.cfg = strdup(&token[5]);
 	else if (!strcmp (token, "-fullname")) Options.fullname = 1;

--- a/yaAGC/agc_cli.h
+++ b/yaAGC/agc_cli.h
@@ -34,6 +34,7 @@
   Reference:	http://www.ibiblio.org/apollo
   Mods:         11/30/08 OH.	Began rework
                 08/04/16 OH     Fixed the GPL statement and old user-id
+                09/30/16 MAS    Added the --inhibit-alarms option
  */
 
 
@@ -58,6 +59,7 @@ typedef struct
   int   debug_dsky;
   int   debug_deda;
   int   deda_quiet;
+  int   inhibit_alarms;
   int   quiet;
   int   fullname;
   int   debug;

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -1681,14 +1681,17 @@ agc_engine (agc_t * State)
         }
 
       // If we triggered any alarms, simulate a GOJAM
-      if (!InhibitAlarms && TriggeredAlarm)
+      if (TriggeredAlarm)
         {
-          // Two single-MCT instruction sequences, GOJAM and TC 4000, are about to happen
-          State->ExtraDelay += 2;
+          if (!InhibitAlarms) // ...but only if doing so isn't inhibited
+            {
+              // Two single-MCT instruction sequences, GOJAM and TC 4000, are about to happen
+              State->ExtraDelay += 2;
 
-          // The net result of those two is Z = 4000. Interrupt state is cleared.
-          c(RegZ) = 04000;
-          State->InIsr = 0;
+              // The net result of those two is Z = 4000. Interrupt state is cleared.
+              c(RegZ) = 04000;
+              State->InIsr = 0;
+            }
 
           // Push the CH77 updates to the outside world
           ChannelOutput (State, 077, State->InputChannel[077]);

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -256,6 +256,9 @@
  *				dividend.
  *		09/11/16 MAS	Applied Gergo's fix for multi-MCT instructions
  *				taking a cycle longer than they should.
+ *		09/30/16 MAS	Added emulation of the Night Watchman hardware
+ *		                alarm, alarm-generated resets, and the CH77
+ *		                restart monitor module.
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,
  * or more particularly for the Apollo Guidance Computer (AGC) may be found at
@@ -427,6 +430,11 @@ WriteIO (agc_t * State, int Address, int Value)
   // Apparently, these are latched inputs, and this resets the latches.
   if (Address == 033)
     Value = (State->InputChannel[Address] | 076000);
+
+  // Similarly, the CH77 Restart Monitor Alarm Box has latches for
+  // alarm codes that are reset when CH77 is written to.
+  if (Address == 077)
+    Value = 0;
 
   State->InputChannel[Address] = Value;
   if (Address == 010)
@@ -1598,6 +1606,8 @@ agc_engine (agc_t * State)
   // This can only iterate once, but I use 'while' just in case.
   while (ScalerCounter >= SCALER_OVERFLOW)
     {
+      int TriggeredAlarm = 0;
+
       // First, update SCALER1 and SCALER2. These are direct views into
       // the clock dividers in the Scaler module, and so don't take CPU
       // time to 'increment'
@@ -1652,9 +1662,46 @@ agc_engine (agc_t * State)
               CpuWriteIO(State, 013, State->InputChannel[013] & 037777);
             }
         }
-      // Return, so as to account for the time occupied by updating the
-      // counters.
-      return (0);
+
+      // Check alarms
+      if (02000 == (03777 & State->InputChannel[ChanSCALER1]))
+        {
+          // The Night Watchman begins looking once every 1.28s...
+          State->NightWatchman = 1;
+        }
+      else if (State->NightWatchman && 00000 == (03777 & State->InputChannel[ChanSCALER1]))
+        {
+          // NEWJOB wasn't checked before 0.64s elapsed. Sound the alarm!
+          TriggeredAlarm = 1;
+
+          // Set the NIGHT WATCHMAN bit in channel 77. Don't go through CpuWriteIO() because
+          // instructions writing to CH77 clear it. We'll broadcast changes to it in the
+          // generic alarm handler a bit further down.
+          State->InputChannel[077] |= CH77_NIGHT_WATCHMAN;
+        }
+
+      // If we triggered any alarms, simulate a GOJAM
+      if (!InhibitAlarms && TriggeredAlarm)
+        {
+          // Two single-MCT instruction sequences, GOJAM and TC 4000, are about to happen
+          State->ExtraDelay += 2;
+
+          // The net result of those two is Z = 4000. Interrupt state is cleared.
+          c(RegZ) = 04000;
+          State->InIsr = 0;
+
+          // Push the CH77 updates to the outside world
+          ChannelOutput (State, 077, State->InputChannel[077]);
+        }
+
+
+      if (State->ExtraDelay)
+        {
+          // Return, so as to account for the time occupied by updating the
+          // counters and/or GOJAM.
+          State->ExtraDelay--;
+          return (0);
+        }
     }
 
   //----------------------------------------------------------------------
@@ -2801,6 +2848,13 @@ agc_engine (agc_t * State)
       // Correct overflow in the L register (this is done on read in the original,
       // but is much easier here)
       c(RegL) = SignExtend (OverflowCorrected (c(RegL)));
+
+      // Check to see if NEWJOB (67) has been accessed for Night Watchman
+      if (Address12 == 067 && !(0100 == ExtendedOpcode & 0170)) // I/O instructions cannot access address 67
+        {
+          // Address 67 has been accessed in some way. Clear the Night Watchman.
+          State->NightWatchman = 0;
+        }
     }
   return (0);
 }

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -88,6 +88,9 @@
 		03/30/09 RSB	Moved Downlink from CpuWriteIO() local variable
 				to agc_t.
 		04/07/09 RSB	Added ProcessDownlinkList and ProcessDownlinkList_t.
+		09/30/16 MAS	Added InhibitAlarms as a configuration global,
+                                NightWatchman to state, and the first constant
+                                related to channel 77.
    
   For more insight, I'd highly recommend looking at the documents
   http://hrst.mit.edu/hrs/apollo/public/archive/1689.pdf and
@@ -226,6 +229,8 @@ extern long random (void);
 #define ChanSCALER1 04
 #define ChanS 07
 
+#define CH77_NIGHT_WATCHMAN 00020
+
 #define NUM_INTERRUPT_TYPES 10
 
 // Max number of 15-bit words in a downlink-telemetry list.
@@ -321,6 +326,7 @@ typedef struct
   unsigned ExtraDelay:3;	// ... and extra, for special cases.
   //unsigned RegQ16:1;		// Bit "16" of register Q.
   unsigned DownruptTimeValid:1;	// Set if the DownruptTime field is valid.
+  unsigned NightWatchman:1;     // Set when Night Watchman is watching. Cleared by accessing address 67.
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   int Downlink;
   // The following pointer is present for whatever use the Orbiter
@@ -340,10 +346,12 @@ typedef struct
 } DebugRule_t;
 #ifdef AGC_ENGINE_C
 int DebugDsky = 0;
+int InhibitAlarms = 0;
 int NumDebugRules = 0;
 DebugRule_t DebugRules[MAX_DEBUG_RULES];
 #else
 extern int DebugDsky;
+extern int InhibitAlarms;
 extern int NumDebugRules;
 extern DebugRule_t DebugRules[MAX_DEBUG_RULES];
 #endif

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -74,6 +74,7 @@
 				saved or restored, so I'm adding all of these.
 		03/30/09 RSB	Added the Downlink variable to the core dumps.
 		08/14/16 OH	Issue #29 fix return value of agc_engine_init.
+		09/30/16 MAS    Added initialization of NightWatchman.
 */
 
 // For Orbiter.
@@ -239,6 +240,8 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->DownruptTimeValid = 1;
   State->DownruptTime = 0;
   State->Downlink = 0;
+
+  State->NightWatchman = 0;
 
   if (CoreDump != NULL)
     {

--- a/yaAGC/agc_simulator.c
+++ b/yaAGC/agc_simulator.c
@@ -34,6 +34,7 @@
   Reference:	http://www.ibiblio.org/apollo
   Mods:         12/02/08 OH.	Began rework
                 08/04/16 OH     Fixed the GPL statement and old user-id
+                09/30/16 MAS    Added the InhibitAlarms option.
  */
 
 
@@ -145,6 +146,8 @@ int SimInitialize(Options_t* Options)
 	DebugDsky = Options->debug_dsky;
 	DebugDeda = Options->debug_deda;
 	DedaQuiet = Options->deda_quiet;
+	InhibitAlarms = Options->inhibit_alarms;
+
 
 	//Simulator.DumpInterval = Simulator.DumpInterval;
 	SocketInterlaceReload = Options->interlace;


### PR DESCRIPTION
This adds emulation for the first of the ALGA alarms (#137), the Night Watchman. It should be very accurate to the behavior of the hardware. Once every 1.28s, it starts looking for accesses to NEWJOB (address 67). If that doesn't happen within 0.64s, a reset is triggered. The reset takes 2 MCTs to get to address 4000, going through the sequences GOJAM and TC 4000. CH77 bits are accrued as alarms are looked at, and then emitted all at the end if any alarms were tripped.

The alarms will always occur and will always update CH77, but their ability to cause a reset can be inhibited with the command-line option --inhibit-alarms. This functionality is exactly analogous to the AGC Monitor signal NHALGA. It's plumbed through in much the same way as DebugDsky.

I also noticed that counter interrupts had the same bug as multi-MCT instructions --i.e., they'd take one more MCT than they were supposed to. I fixed that by decrementing ExtraDelay before returning at the end of the counter/alarm update block.

With this, Aurora 12 no longer gets stuck in the "00 lockup" (see #105) -- the Night Watchman successfully detects the infinite loop, causes a reset, and after the reset everything works fine. I've tested --inhibit-alarms this way, and with alarms inhibited, the 00 lockup remains inescapable.

There's required changes to Validation to keep it from angering the watchman when running without alarms inhibited. I'll handle those before merging this in.

@rburkey2005, how does this look to you?