### PR TITLE
DV fixes based on Aurora tests

### DIFF
--- a/Validation/SmallyDVCHECK.agc
+++ b/Validation/SmallyDVCHECK.agc
@@ -196,7 +196,6 @@
 		TCF	DVERROR
 		CCS	L			# Smally says -0, but I think +0.
 		TCF	DVERROR
-		TCF	+3
 		TCF	DVERROR
 		TCF	DVERROR
 		

--- a/Validation/SmallyDVCHK.agc
+++ b/Validation/SmallyDVCHK.agc
@@ -129,7 +129,7 @@
 		EXTEND
 		BZF	+2
 		TCF	DVCERROR
-		CA	L
+		CS	L
 		AD	MAXP-1
 		EXTEND
 		BZF	+2

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -2549,29 +2549,36 @@ agc_engine (agc_t * State)
 	      c (RegL) = (0777777 & random ());
 	      c (RegA) = (0177777 & random ());
 	    }
+	  else if (AbsA == 0 && AbsL == 0)
+	    {
+	      // The dividend is 0 but the divisor is not. The standard DV sign
+	      // convention applies to A, and L remains unchanged.
+	      if ((040000 & c (RegL)) == (040000 & *WhereWord))
+                {
+                  if (AbsK == 0) Operand16 = 037777;	// Max positive value.
+                  else Operand16 = AGC_P0;
+                }
+	      else
+                {
+                  if (AbsK == 0) Operand16 = (077777 & ~037777);	// Max negative value.
+                  else Operand16 = AGC_M0;
+                }
+
+	      c (RegA) = SignExtend (Operand16);
+	    }
 	  else if (AbsA == AbsK && AbsL == AGC_P0)
 	    {
 	      // The divisor is equal to the dividend.
 	      if (AccPair[0] == *WhereWord)// Signs agree?
 		{
 		  Operand16 = 037777;	// Max positive value.
-		  c (RegL) = SignExtend (*WhereWord);
 		}
 	      else
 		{
 		  Operand16 = (077777 & ~037777);	// Max negative value.
-		  c (RegL) = SignExtend (*WhereWord);
 		}
+	      c (RegL) = AccPair[0];
 	      c (RegA) = SignExtend (Operand16);
-	    }
-	  else if (AbsA == 0 && AbsL == 0 && AbsK != 0)
-	    {
-	      // The dividend is 0 but the divisor is not. The standard DV sign
-	      // convention applies to A, and L remains unchanged.
-	      if ((040000 & c (RegL)) == (040000 & *WhereWord))
-	        c (RegA) = AGC_P0;
-	      else
-	        c (RegA) = SignExtend (AGC_M0);
 	    }
 	  else
 	    {


### PR DESCRIPTION
There were two separate problems with DV that Aurora caught:

1. When the dividend and divisor have the same magnitude, the remainder (L) should receive the quotient rather than the divisor. This had come up before as a difference between the hardware sim and yaAGC -- Aurora just confirmed the suspicion that yaAGC was incorrect.

2. Completely unexpectedly, the two cases "dividend == divisor" and "dividend == +-0" blend together when dividing 0 by 0. Like the former case, A receives posmax or negmax. And like the latter case, L remains unchanged (unlike in the former). This mish-mash of special cases was caught by the extensive arithmetic divide tests in DVCHECK.

With these corrections in place, Aurora passes both DVCHK (control pulses) and DVCHECK (extensive arithmetic) tests for the DV instruction, so we've hopefully finally got it right.

Now that it's getting past DVCHK, it's failing on RUPTCHK. I don't yet know why.