### PR TITLE
yaAGC+yaDSKY2: Updates to make DSKY handling more 'realistic'

### DIFF
--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -229,9 +229,15 @@ extern long random (void);
 #define ChanSCALER1 04
 #define ChanS 07
 
-#define CH77_TC_TRAP        00004
-#define CH77_RUPT_LOCK      00010
-#define CH77_NIGHT_WATCHMAN 00020
+#define CH77_TC_TRAP        000004
+#define CH77_RUPT_LOCK      000010
+#define CH77_NIGHT_WATCHMAN 000020
+
+#define DSKY_KEY_REL  000020
+#define DSKY_VN_FLASH 000040
+#define DSKY_OPER_ERR 000100
+#define DSKY_RESTART  000200
+#define DSKY_STBY     000400
 
 #define NUM_INTERRUPT_TYPES 10
 

--- a/yaDSKY2/CM.ini
+++ b/yaDSKY2/CM.ini
@@ -1,0 +1,238 @@
+# Copyright:	None.  The author, Ron Burkey, hereby places
+#		this file into the public domain.
+# Filename:	CM.ini
+# Purpose: 	This is a configuration file used by the
+#		program yaDSKY and (in some modes) yaAGC.
+#		This particular file configures
+#		for a typical Apollo CM DSKY.
+# Mod history:	08/17/03 RSB.	Created.
+#		08/19/03 RSB.	Added yaAGC test mode.
+#		08/20/03 RSB.	Added PRO key for --debug-dsky.
+#		07/11/04 RSB.	Added mappings for GIMBAL LOCK,
+#				PROG, NO ATT, TRACKER, and
+#				STBY indicators.
+#		06/27/05 RSB.	Added CMSIM.
+
+# The idea of the configuration file is to allow us to
+# configure yaDSKY for the DSKYs used in different Apollo
+# missions (or for CM vs. LM), without having to modify
+# yaDSKY's source code.  The particular configuration file
+# needed is selected at the yaDSKY command line.  Read the
+# comments below to see how to modify the configuration file.
+
+# -------------------------------------------------------------
+# The following line determines if this is a CM or LM simulation.
+#LMSIM
+CMSIM
+
+# -------------------------------------------------------------
+# The following line determines which graphic file is used
+# for the PRO/STBY/PROG pushbutton.  Examine the graphic file
+# within an editor (such as The GIMP) if you want to see its
+# characteristics.  The syntax is the word "PROKEY", followed
+# by whitespace, followed by the name of the graphics file.
+PROKEY ProUp.xpm
+
+# -------------------------------------------------------------
+# The following lines determine which graphic files are
+# used to simulate the 14 indicator lamps.  The lamps,
+# which are in two columns of 7 lamps each, are numbered
+#	11	21
+#	12	22
+#	.	.
+#	.	.
+#	.	.
+#	17	27
+# Graphics must be provided both for the "on" (lit) condition
+# and the "off" (dark) condition.  Fields within a line are
+# separated by whitespace, are are as follows:  the word
+# "IND", the number of the indicator lamp (11, 21, ..., 77),
+# the filename of the graphic for the lit condition, and the
+# filename of the graphic for the dark condtion.  The lines
+# appear in no particular order.
+#
+# Note that at least one of the lines should contain the substring
+# "KeyRel" and another should contain the substring "OprErr".
+# (If not, then yaDSKY will be unable to flash the KEY REL or
+# OPR ERR indicators.)
+IND 11 UplinkActyOn.xpm UplinkActyOff.xpm
+IND 12 NoAttOn.xpm NoAttOff.xpm
+IND 13 StbyOn.xpm StbyOff.xpm
+IND 14 KeyRelOn.xpm KeyRelOff.xpm
+IND 15 OprErrOn.xpm OprErrOff.xpm
+IND 16 BlankOn.xpm BlankOff.xpm
+IND 17 BlankOn.xpm BlankOff.xpm
+IND 21 TempOn.xpm TempOff.xpm
+IND 22 GimbalLockOn.xpm GimbalLockOff.xpm
+IND 23 ProgOn.xpm ProgOff.xpm
+IND 24 RestartOn.xpm RestartOff.xpm
+IND 25 TrackerOn.xpm TrackerOff.xpm
+IND 26 BlankOn.xpm BlankOff.xpm
+IND 27 BlankOn.xpm BlankOff.xpm
+
+# -------------------------------------------------------------
+# The following lines determine which bit-positions of which
+# of the CPU's "output channels" correspond to the various
+# indicator lamps (which are numbered as described above).
+# The fields with the lines are delimited by whitespace.
+# the fields are:  the word "CHAN", the number of the indicator
+# lamp (11, ..., 77), the number (in octal) of the output
+# channel, the bit position (in decimal) of the flag that
+# indicates whether the lamp should be lit or not, and a
+# flag (0 or 1) indicating the polarity of the signal.
+# (The polarity is XOR-ed with the bitflag.)  Note that the
+# numerical bases (octal vs. decimal) have been chosen to
+# mimic the Luminary/Colossus source code.
+#
+# Note that some of the CHAN lines have 6 numbers rather 
+# than 4 numbers.  This is because some of the indicator
+# lights depend not only in bit flags within the output channel,
+# but also on certain fields ("row latches") matching a certain
+# pattern.  The fifth number is a mask (in octal) which must be
+# applied to the value emitted on the output channel, while
+# the sixth number is the number which must appear in that 
+# masked field.
+#
+# Explanation:  There is a Apollo Guidance Computer (AGC)
+# CPU instruction which can output a 15-bit word to an "output
+# channel", and by this means can control peripheral devices
+# like the DSKY.  The bits are numbered 1 through 15, with
+# 1 being the least-significant bit.
+#
+# ... But!  I haven't been able so far to find the i/o
+# mapping within the Colossus source code.  The values that
+# follow are from Luminary131 source code, and are themselves
+# incomplete.
+CHAN 11  11  3 0		# UPLINK ACTY
+CHAN 12  10  4 0 74000 60000	# NO ATT
+CHAN 13 163  9 0		# STBY
+CHAN 14 163  5 0		# KEY REL
+CHAN 15 163  7 0		# OPR ERR
+CHAN 16 377  1 0		# (not used in Colossus)
+CHAN 17 377  1 0		# (not used in Colossus)
+CHAN 21  11  4 0		# TEMP
+CHAN 22  10  6 0 74000 60000	# GIMBAL LOCK
+CHAN 23  10  9 0 74000 60000	# PROG
+CHAN 24 163  8 0                # RESTART
+CHAN 25  10  8 0 74000 60000	# TRACKER
+CHAN 26 377  1 0		# (not used in Colossus)
+CHAN 27 377  1 0		# (not used in Colossus)
+
+# -------------------------------------------------------------
+# The following lines are actually for yaAGC rather than for
+# yaDSKY.  They determine the behavior of yaAGC whilst in
+# "--debug-dsky" mode.  In that mode, rather than running
+# AGC software, yaAGC echoes command-sequences to the DSKY
+# (or other peripherals) in response to keystrokes from the
+# DSKY.  The particular command-sequences used are defined here.
+# If no command-sequences are defined here, then the --debug-dsky
+# mode is not functional.  The syntax of any given line is:
+#	DEBUG KeyCode Channel Logic Value
+# KeyCode is decimal, Channel is octal, and Value is hexadecimal.
+# The KeyCode is the numerical value which the DSKY provides to
+# the CPU (i.e., to yaAGC) upon the key being pressed.  These
+# keycodes are:
+#	Key			KeyCode
+#	---			-------
+#	1			1
+#	...			...
+#	9			9
+#	0			16
+#	VERB			17
+#	RSET			18
+#	KEY REL			25
+#	+			26
+#	-			27
+#	ENTR			28
+#	CLR			30
+#	NOUN			31
+#	PRO/STBY/PROG		Different mechanism, but for
+#				this purpose ONLY is treated
+#				as the fictitious KeyCode 0.
+# As many DEBUG lines can be defined for a given KeyCode as you
+# like; they will all be used, in the order given.  The Channel
+# is the output channel on which the command is transmitted.
+# The Logic field is as follows:
+#	Logic		Interpretation
+#	-----		--------------
+#	=		Outputs Value on the Channel
+#	|		Bitwise-OR Value with the last
+#			output on the Channel.
+#	&		Bitwise-AND Value with the last
+#			output on the Channel.
+#	^		Bitwise-XOR Value with the last
+#			output on the Channel.
+# Thus, any bit-positions (or combination of bit-positions)
+# on any Channel can be selectively set, reset, or toggled
+# without affecting any other bits.  Or, sequences of outputs
+# could be used to write to the numerical displays.  More
+# complex debugging behaviors might be desirable under some
+# circumstances, but you'll have to modify yaAGC source code
+# if you want to implement them.
+#
+# IMPORTANT:  The Logic field should be preceded by precisely
+# one blank space.
+
+# PRO-key.  Toggle DSKY test mode.
+DEBUG 0 13 ^ 0200
+# 1-key.  Display "1" on top 5-digit display.
+DEBUG 1 10 = 4000
+DEBUG 1 10 = 3800
+DEBUG 1 10 = 3003
+# 2-key.  Display "2" on top 5-digit display.
+DEBUG 2 10 = 4000
+DEBUG 2 10 = 3800
+DEBUG 2 10 = 3019
+# 3-key.  Display "3" on top 5-digit display.
+DEBUG 3 10 = 4000
+DEBUG 3 10 = 3800
+DEBUG 3 10 = 301b
+# 4-key.  Display "4" on top 5-digit display.
+DEBUG 4 10 = 4000
+DEBUG 4 10 = 3800
+DEBUG 4 10 = 300f
+# 5-key.  Display "5" on top 5-digit display.
+DEBUG 5 10 = 4000
+DEBUG 5 10 = 3800
+DEBUG 5 10 = 301e
+# 6-key.  Display "6" on top 5-digit display.
+DEBUG 6 10 = 4000
+DEBUG 6 10 = 3800
+DEBUG 6 10 = 301c
+# 7-key.  Display "7" on top 5-digit display.
+DEBUG 7 10 = 4000
+DEBUG 7 10 = 3800
+DEBUG 7 10 = 3013
+# 8-key.  Display "8" on top 5-digit display.
+DEBUG 8 10 = 4000
+DEBUG 8 10 = 3800
+DEBUG 8 10 = 301d
+# 9-key.  Display "9" on top 5-digit display.
+DEBUG 9 10 = 4000
+DEBUG 9 10 = 3800
+DEBUG 9 10 = 301f
+# 0-key.  Display "0" on top 5-digit display.
+DEBUG 16 10 = 4000
+DEBUG 16 10 = 3800
+DEBUG 16 10 = 3015
+# VERB-key.  Toggle "TEMP" lamp.
+DEBUG 17 11 ^ 8
+# RSET-key.  Clear all lamps and numerical displays.
+DEBUG 18 11 = 0
+DEBUG 18 10 = 4000
+DEBUG 18 10 = 3800
+DEBUG 18 10 = 3000
+# KEY REL key.  Toggle "KEY REL" lamp.
+DEBUG 25 11 ^ 10
+# + key.  Toggle VERB/NOUN flashing.
+DEBUG 26 11 ^ 20
+# - key.  Toggle "UPLINK ACTY" lamp.
+DEBUG 27 11 ^ 4
+# ENTR-key.  Display "+12345" on top 5-digit display.
+DEBUG 28 10 = 4003
+DEBUG 28 10 = 3f3b
+DEBUG 28 10 = 31fe
+# CLR-key.  Toggle "COMP ACTY" indicator.
+DEBUG 30 11 ^ 2
+# NOUN-key.  Toggle "OPR ERR" lamp.
+DEBUG 31 11 ^ 40

--- a/yaDSKY2/LM.ini
+++ b/yaDSKY2/LM.ini
@@ -1,17 +1,22 @@
 # Copyright:	None.  The author, Ron Burkey, hereby places
 #		this file into the public domain.
-# Filename:	CM.ini
+# Filename:	LM.ini
 # Purpose: 	This is a configuration file used by the
-#		program yaDSKY and (in some modes) yaAGC.
-#		This particular file configures
-#		for a typical Apollo CM DSKY.
+#		program yaDSKY.  This particular file configures
+#		yaDSKY for a typical Apollo LM DSKY.
 # Mod history:	08/17/03 RSB.	Created.
-#		08/19/03 RSB.	Added yaAGC test mode.
-#		08/20/03 RSB.	Added PRO key for --debug-dsky.
-#		07/11/04 RSB.	Added mappings for GIMBAL LOCK,
-#				PROG, NO ATT, TRACKER, and
-#				STBY indicators.
-#		06/27/05 RSB.	Added CMSIM.
+#		08/19/03 RSB.	Added --debug-dsky settings.
+#		08/20/03 RSB.	Connected PRO key to DSKY test
+#				mode with --debug-dsky.
+#		05/10/04 RSB	Corrected the PRO key.
+#		07/11/04 RSB	Added mappings for the indicators
+#				GIMBAL LOCK, NO ATT, PROG, STBY,
+#				and TRACKER.
+#		07/17/04 RSB	Finally got rid of the PRIO DISP
+#				and NO DAP indicators.  Also,
+#				added the control signals for
+#				ALT and VEL, thanks to Julian.
+#		06/27/05 RSB	Added LMSIM.
 
 # The idea of the configuration file is to allow us to
 # configure yaDSKY for the DSKYs used in different Apollo
@@ -22,8 +27,8 @@
 
 # -------------------------------------------------------------
 # The following line determines if this is a CM or LM simulation.
-#LMSIM
-CMSIM
+LMSIM
+#CMSIM
 
 # -------------------------------------------------------------
 # The following line determines which graphic file is used
@@ -67,8 +72,8 @@ IND 22 GimbalLockOn.xpm GimbalLockOff.xpm
 IND 23 ProgOn.xpm ProgOff.xpm
 IND 24 RestartOn.xpm RestartOff.xpm
 IND 25 TrackerOn.xpm TrackerOff.xpm
-IND 26 BlankOn.xpm BlankOff.xpm
-IND 27 BlankOn.xpm BlankOff.xpm
+IND 26 AltOn.xpm AltOff.xpm
+IND 27 VelOn.xpm VelOff.xpm
 
 # -------------------------------------------------------------
 # The following lines determine which bit-positions of which
@@ -104,15 +109,15 @@ CHAN 12  10  4 0 74000 60000	# NO ATT
 CHAN 13 163  9 0		# STBY
 CHAN 14 163  5 0		# KEY REL
 CHAN 15 163  7 0		# OPR ERR
-CHAN 16 377  1 0		# (not used in Colossus)
-CHAN 17 377  1 0		# (not used in Colossus)
+CHAN 16  10  2 0 74000 60000	# NO DAP
+CHAN 17  10  1 0 74000 60000	# PRIO DISP
 CHAN 21  11  4 0		# TEMP
 CHAN 22  10  6 0 74000 60000	# GIMBAL LOCK
 CHAN 23  10  9 0 74000 60000	# PROG
-CHAN 24 163  8 0                # RESTART
+CHAN 24 163  8 0		# RESTART
 CHAN 25  10  8 0 74000 60000	# TRACKER
-CHAN 26 377  1 0		# (not used in Colossus)
-CHAN 27 377  1 0		# (not used in Colossus)
+CHAN 26  10  5 0 74000 60000    # ALT
+CHAN 27  10  3 0 74000 60000    # VEL
 
 # -------------------------------------------------------------
 # The following lines are actually for yaAGC rather than for

--- a/yaDSKY2/yaDSKY2.h
+++ b/yaDSKY2/yaDSKY2.h
@@ -218,11 +218,12 @@ public:
     virtual void on_NineButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
     virtual void on_SixButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
     virtual void on_ClrButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
-    virtual void on_ProButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
+    virtual void on_ProButton_pressed(wxMouseEvent &event); // wxGlade: <event_handler>
     virtual void on_KeyRelButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
     virtual void on_EntrButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
     virtual void on_RsetButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
     virtual void on_ThreeButton_pressed(wxCommandEvent &event); // wxGlade: <event_handler>
+    virtual void on_LeftMouse_released(wxMouseEvent &event);
     virtual void HotkeyEvent (wxKeyEvent &event);
 }; // wxGlade: end class
 


### PR DESCRIPTION
Here's the first batch of updates to yaAGC and yaDSKY2 to make DSKY handling a bit more realistic.
First, a gif of me testing the changes in Aurora (yes, I know it's a CM DSKY :P):
![dsky_updates](https://cloud.githubusercontent.com/assets/94056/19018152/8aa9ee8e-880b-11e6-829d-f318c7483a19.gif)

And a description of what's going on:
1. Computer is started, which lights RESTART
2. V35E is entered, which performs a light test. Because the RESTART light was active, it is not extinguished after the test.
3. The RESTART light is acknowledged with RSET and turns off.
4. V35E is reentered. RESTART turns on for the light test, but goes off after the end.
5. V01N10E 77E is entered to show the state of the hardware alarm latches. Because I started with a previously used Aurora core dump, it's all 0.
6. The control pulse self test is started with V21N27E 1E. This is on my master branch, and the RUPTCHK fixes are not in yet, so RUPTCHK fails. When it fails, it tries again and again, rather quickly. 
7. Eventually the computer panics and a hardware alarm gets triggered. RESTART is lit, and the computer reboots.
8. V01N10E 77E is again used to check what caused the RESTART. It now shows 00010, which corresponds to a Rupt Lock. (I guess WHIMPER is being called from within the TIME3 ISR, since that's where the failing check is).
9. Finally, the new RESTART is acknowledged with RSET, and the light goes off.

Now for the details:

This adds the fictitious output channel 163, whose bits correspond essentially 1-1 with discretes to the real DSKY. Verb/Noun, KEY REL and OPER ERR flashing is now timed by the AGC itself (with VN being active low, and the others being active high).

The RESTART light has also been plumbed through this channel. It is set by turning the computer on, or getting a GOJAM from a hardware alarm. It can also be temporarily turned on via the Alarm Test bit in channel 13. It's extinguished via a reset bit from channel 10.

Note that none of these changes break backwards compatibility for previous DSKY interfaces to yaAGC. They simply add a new one, and modify yaDSKY2 to use that instead for some things.

My next goal is to get standby and its associated light working.