### PR TITLE
Use common Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Comanche055/Comanche055.lst
 Luminary099/Luminary099.lst
 Luminary131/Luminary131.lst
 Solarium055/Solarium055.lst
+oct2bin.proof

--- a/Artemis072/Makefile
+++ b/Artemis072/Makefile
@@ -22,28 +22,7 @@
 #				a rebuild the next time make is run.
 #				Remove obsolete stuff. Point to moved Oct2Bin.
 #		2012-09-16 JL	Updated to match tools dir changes.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Artemis072
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
+include ../Makefile.inc

--- a/Aurora12/Makefile
+++ b/Aurora12/Makefile
@@ -4,29 +4,7 @@
 # Contact:	Ron Burkey <info@sandroid.org>.
 # Website:	http://www.ibiblio.org/apollo
 # Mod history:	2016-09-20 JL	Adapted from similar Luminary 099 Makefile.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Aurora12
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
-
+include ../Makefile.inc

--- a/Colossus249/Makefile
+++ b/Colossus249/Makefile
@@ -16,28 +16,7 @@
 #		2011-05-03 JL	Replaced with newer version from Artemis072.
 #				Point to moved Oct2Bin.
 #		2012-09-16 JL	Updated to match tools dir changes.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Colossus249
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
+include ../Makefile.inc

--- a/Comanche055/Makefile
+++ b/Comanche055/Makefile
@@ -5,34 +5,12 @@
 #		Apollo Guidance Computer (AGC), Apollo 11.)
 # Contact:	Ron Burkey <info@sandroid.org>.
 # Website:	http://www.ibiblio.org/apollo
-# Mod history:	2009-05-20 RSB	Adapted from similar Colossus 249
-#				Makefile.
+# Mod history:	2009-05-20 RSB	Adapted from similar Colossus 249 Makefile.
 #		2009-07-04 RSB	Added --html switch.
 #		2011-05-03 JL	Replaced with newer version from Artemis072.
-#				Point to moved Oct2Bin.
-#               2012-09-16 JL   Updated to match tools dir changes.
+#						Point to moved Oct2Bin.
+#		2012-09-16 JL	Updated to match tools dir changes.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Comanche055
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
+include ../Makefile.inc

--- a/Luminary099/Makefile
+++ b/Luminary099/Makefile
@@ -11,29 +11,7 @@
 #		2011-05-03 JL	Fixed so that errors will cause rebuild next
 #				time make is run. Point to moved Oct2Bin.
 #		2012-09-16 JL	Updated to match tools dir changes.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Luminary099
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
-
+include ../Makefile.inc

--- a/Luminary131/Makefile
+++ b/Luminary131/Makefile
@@ -19,29 +19,7 @@
 #		2011-05-03 JL	Moved oct2bin, checkdec, bdiffhead, webb2burkey-rope to Tools directory. 
 #				Changed to simpler Makefile based on Artemis072.
 #		2012-09-16 JL	Updated to match tools dir changes.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Luminary131
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
-
+include ../Makefile.inc

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,0 +1,39 @@
+# Copyright:	Public domain.
+# Filename:	Makefile
+# Purpose:	Makefile include for all flights.
+# Contact:	Ron Burkey <info@sandroid.org>.
+# Website:	http://www.ibiblio.org/apollo
+# Mod history:	2016-10-04 JL   Created.
+#               2016-10-04 JL   Added format target.
+
+# Note: $(BASENAME) must be set by calling Makefile to the flight name.
+
+SOURCE:=$(wildcard *.agc)
+TARGETS=${BASENAME}.bin ${BASENAME}.lst 
+
+default: $(TARGETS)
+
+${BASENAME}.bin: ${BASENAME}.binsource
+	../Tools/oct2bin <${BASENAME}.binsource
+	mv oct2bin.bin $@
+
+MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
+	../yaYUL/yaYUL $(EXTRA_YUL_ARGS) --unpound-page --html MAIN.agc >MAIN.agc.lst
+
+${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
+	diff -s MAIN.agc.bin ${BASENAME}.bin
+	mv MAIN.agc.lst ${BASENAME}.lst
+	mv MAIN.agc.symtab ${BASENAME}.symtab
+
+corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
+	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
+
+clean:
+	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
+
+%.agc.out: %.agc 
+	../yaYUL/yaYUL --format $< >$@
+	mv -f $@ $<
+
+format: $(SOURCE:.agc=.agc.out)
+

--- a/Solarium055/Makefile
+++ b/Solarium055/Makefile
@@ -11,28 +11,8 @@
 #		2016-08-24 RSB	Added --block1 switch to yaYUL command line.
 #		2016-08-24 RSB	Added target for corediff.txt.
 #		2016-08-24 RSB	... and other stuff related to that too.
+#		2016-10-04 JL	Change to use Makefile.inc.
 
 BASENAME=Solarium055
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --block1 --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
+EXTRA_YUL_ARGS="--block1"
+include ../Makefile.inc

--- a/Sunburst120/Makefile
+++ b/Sunburst120/Makefile
@@ -5,35 +5,9 @@
 #		Apollo Guidance Computer (AGC), Apollo 11.)
 # Contact:	Ron Burkey <info@sandroid.org>.
 # Website:	http://www.ibiblio.org/apollo
-# Mod history:	2009-06-05 RSB	Adapted from similar Comanche 055
-#				Makefile.
-#		2009-07-04 RSB	Added --html switch.
-#		2011-05-03 JL	Fixed so that errors will cause rebuild next
-#				time make is run. Point to moved Oct2Bin.
-#		2012-09-16 JL	Updated to match tools dir changes.
+# Mod history:	2016-09-29 RSB	created.
+# 		2016-10-04 JL	Change to use Makefile.inc.
 
-BASENAME=Luminary099
-
-SOURCE:=$(wildcard *.agc)
-TARGETS=${BASENAME}.bin ${BASENAME}.lst 
-
-default: $(TARGETS)
-
-${BASENAME}.bin: ${BASENAME}.binsource
-	../Tools/oct2bin <${BASENAME}.binsource
-	mv oct2bin.bin $@
-
-MAIN.agc.bin MAIN.agc.lst: ${SOURCE}
-	../yaYUL/yaYUL --unpound-page --html MAIN.agc >MAIN.agc.lst
-
-${BASENAME}.lst: MAIN.agc.bin ${BASENAME}.bin
-	diff -s MAIN.agc.bin ${BASENAME}.bin
-	mv MAIN.agc.lst ${BASENAME}.lst
-	mv MAIN.agc.symtab ${BASENAME}.symtab
-
-corediff.txt: ${BASENAME}.bin MAIN.agc.bin MAIN.agc.lst
-	python ../Tools/ropediff.py -p -c -a -o $@ ${BASENAME}.bin MAIN.agc.bin
-
-clean:
-	rm -f *.lst *~ MAIN.agc.bin ${BASENAME}.bin *.symtab oct2bin.bin* *.html
-
+BASENAME=Sunburst120
+EXTRA_YUL_ARGS="--blk2"
+include ../Makefile.inc


### PR DESCRIPTION
Change the flight builds to use a common make include file (`Makefile.inc` at top-level). 

 - This means we can modify build rules in one place. 
 - Differences in YUL options per-flight are specified using the `EXTRA_YUL_ARGS` variable, see `Solarium055` for an example.
 - Added a `format` target. This reformats all the sources in a flight directory with `yaYUL --format`.