### PR TITLE
Add format-missions target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ clean-missions:
 	for subdir in $(MISSIONS) ; do make -C $$subdir clean ; done
 
 format-missions:
-	for subdir in $(MISSIONS) ; do make -C $$subdir format ; done
+	for subdir in $(MISSIONS) ; do REFORMAT=no make -C $$subdir format ; done
 
 .PHONY: corediffs
 corediffs: yaYUL Tools

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@
 #				were included in the installer.
 #		2016-08-29 RSB	Mods related to my personal-build situation, which
 #				shouldn't affect anyone else.
+#		2016-10-04 JL	Added 'format-missions' rukle to reformat all 
+#				mission sources using yaYUL.
 #
 # The build box is always Linux for cross-compiles.  For native compiles:
 #	Use "make MACOSX=yes" for Mac OS X.
@@ -309,7 +311,7 @@ endif # NOGUI
 .PHONY: default
 default: all
 
-.PHONY: missions $(MISSIONS) clean-missions
+.PHONY: missions $(MISSIONS) clean-missions format-missions
 missions: $(MISSIONS)
 
 $(MISSIONS): yaYUL Tools
@@ -317,6 +319,9 @@ $(MISSIONS): yaYUL Tools
 
 clean-missions:
 	for subdir in $(MISSIONS) ; do make -C $$subdir clean ; done
+
+format-missions:
+	for subdir in $(MISSIONS) ; do make -C $$subdir format ; done
 
 .PHONY: corediffs
 corediffs: yaYUL Tools

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,8 +1,8 @@
 # Copyright:	Public domain.
-# Filename:	Makefile
-# Purpose:	Makefile include for all flights.
-# Contact:	Ron Burkey <info@sandroid.org>.
-# Website:	http://www.ibiblio.org/apollo
+# Filename: 	Makefile.inc
+# Purpose:  	Makefile include for all flights.
+# Contact:  	Ron Burkey <info@sandroid.org>.
+# Website:  	http://www.ibiblio.org/apollo
 # Mod history:	2016-10-04 JL   Created.
 #               2016-10-04 JL   Added format target.
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -33,7 +33,9 @@ clean:
 
 %.agc.out: %.agc 
 	../yaYUL/yaYUL --format $< >$@
+ifeq "$(REFORMAT)" "yes"
 	mv -f $@ $<
+endif
 
 format: $(SOURCE:.agc=.agc.out)
 


### PR DESCRIPTION
Add a top-level `format-missions` target that reformats all AGC source using `yaYUL`.
Fixed Makefile.inc header comments.