### PR TITLE
yaAGC: Added support for standby mode

### DIFF
--- a/yaAGC/SocketAPI.c
+++ b/yaAGC/SocketAPI.c
@@ -259,6 +259,10 @@ ChannelInput (agc_t *State)
 			      State->InterruptRequests[10] = 1;
 			    LastInDetent = InDetent;
 			  }
+                        else if (Channel == 032 && 0 != (Value & 020000))
+			  {
+			    State->SbyPressed = 0;
+			  }
 			//---------------------------------------------------------------
 			// For --debug-dsky mode.
 			if (DebugDsky)
@@ -271,6 +275,7 @@ ChannelInput (agc_t *State)
 				  {
 				    Channel = 015;
 				    Value = 0;
+				    State->SbyPressed = 0;
 				  }
 			      }
 			    if (Channel == 015)

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -1488,7 +1488,7 @@ BurstOutput (agc_t *State, int DriveBitMask, int CounterRegister, int Channel)
 // it requires slightly more processing, in order to conform as obviously
 // as possible to the MIT docs.
 
-#define SCALER_OVERFLOW 160
+#define SCALER_OVERFLOW 80
 #define SCALER_DIVIDER 3
 static int ScalerCounter = 0;
 
@@ -1610,26 +1610,31 @@ agc_engine (agc_t * State)
 
       // ... but turn it on if the alarm test is active
       if (State->InputChannel[013] & 01000)
-        DskyChannel163 |= DSKY_RESTART;
+        DskyChannel163 |= DSKY_RESTART | DSKY_STBY;
+      else if (!State->Standby)
+        DskyChannel163 &= ~DSKY_STBY;
 
       // Flashing lights on the DSKY have a period of 1.28s, and a 75% duty cycle
-      if (DskyFlash == 0)
+      if (!State->Standby)
         {
-          // If V/N FLASH is high, then the lights are turned off
-          if (State->InputChannel[011] & DSKY_VN_FLASH)
-            DskyChannel163 |= DSKY_VN_FLASH;
-        }
-        else
-        {
-          // If KEY REL or OPER ERR are high, those lights are turned on
-          if (State->InputChannel[011] & DSKY_KEY_REL)
-            DskyChannel163 |= DSKY_KEY_REL;
-          if (State->InputChannel[011] & DSKY_OPER_ERR)
-            DskyChannel163 |= DSKY_OPER_ERR;
+          if (DskyFlash == 0)
+            {
+              // If V/N FLASH is high, then the lights are turned off
+              if (State->InputChannel[011] & DSKY_VN_FLASH)
+                DskyChannel163 |= DSKY_VN_FLASH;
+            }
+            else
+            {
+              // If KEY REL or OPER ERR are high, those lights are turned on
+              if (State->InputChannel[011] & DSKY_KEY_REL)
+                DskyChannel163 |= DSKY_KEY_REL;
+              if (State->InputChannel[011] & DSKY_OPER_ERR)
+                DskyChannel163 |= DSKY_OPER_ERR;
+            }
         }
 
-        // Send out updated display information
-        ChannelOutput(State, 0163, DskyChannel163);
+      // Send out updated display information
+      ChannelOutput(State, 0163, DskyChannel163);
     }
 
   // If in --debug-dsky mode, don't want to take the chance of executing
@@ -1669,8 +1674,8 @@ agc_engine (agc_t * State)
     }
 
   //----------------------------------------------------------------------
-  // Here we take care of counter-timers.  There is a basic 1/1600 second
-  // clock that is used to drive the timers.  1/1600 second happens to
+  // Here we take care of counter-timers.  There is a basic 1/3200 second
+  // clock that is used to drive the timers.  1/3200 second happens to
   // be SCALER_OVERFLOW/SCALER_DIVIDER machine cycles, and the variable
   // ScalerCounter has already been updated the correct number of 
   // multiples of SCALER_DIVIDER.  Note that incrementing a timer register
@@ -1691,97 +1696,139 @@ agc_engine (agc_t * State)
           State->InputChannel[ChanSCALER1] = 0;
           State->InputChannel[ChanSCALER2] = (State->InputChannel[ChanSCALER2] + 1) & 037777;
         }
-      // Check whether there was a pulse into bit 5 of SCALER1.
-      // If so, the 10 ms. timers TIME1 and TIME3 are updated.
-      // Recall that the registers are in AGC integer format,
-      // and therefore are actually shifted left one space.
-      if (0 == (017 & State->InputChannel[ChanSCALER1]))
-	{
-	  State->ExtraDelay++;
-	  if (CounterPINC (&c(RegTIME1)))
-	    {
-	      State->ExtraDelay++;
-	      CounterPINC (&c(RegTIME2));
-	    }
-	  State->ExtraDelay++;
-	  if (CounterPINC (&c(RegTIME3)))
-	    State->InterruptRequests[3] = 1;
-	}
-      // TIME5 is the same as TIME3, but 5 ms. out of phase.
-      if (010 == (017 & State->InputChannel[ChanSCALER1]))
-	{
-	  State->ExtraDelay++;
-	  if (CounterPINC (&c(RegTIME5)))
-	    State->InterruptRequests[2] = 1;
-	}
-      // TIME4 is the same as TIME3, but 7.5ms out of phase
-      if (014 == (017 & State->InputChannel[ChanSCALER1]))
-	{
-	  State->ExtraDelay++;
-	  if (CounterPINC (&c(RegTIME4)))
-	    State->InterruptRequests[4] = 1;
-	}
-      // TIME6 only increments when it has been enabled via CH13 bit 15.
-      // It increments 0.3125ms after TIME1/TIME3, half of the 1/1600 second
-      // clock period as accounted for here. I'm assuming that difference
-      // is small enough, though, and just incrementing along with TIME1
-      if (040000 & State->InputChannel[013])
+
+      // Check alarms first, since there's a chance we might go to standby
+      if (04000 == (07777 & State->InputChannel[ChanSCALER1]))
         {
-          State->ExtraDelay++;
-          if (CounterDINC (State, 0, &c(RegTIME6)))
+          // The Night Watchman begins looking once every 1.28s...
+          if (!State->Standby)
+            State->NightWatchman = 1;
+
+          // Same with Standby
+          if (0 == (State->InputChannel[032] & 020000))
+            State->SbyPressed = 1;
+
+        }
+      else if (00000 == (07777 & State->InputChannel[ChanSCALER1]))
+        {
+          if (State->SbyPressed && State->InputChannel[013] & 002000)
             {
-	      State->InterruptRequests[1] = 1;
-              // Triggering a T6RUPT disables T6 by clearing the CH13 bit
-              CpuWriteIO(State, 013, State->InputChannel[013] & 037777);
+              if (!State->Standby)
+                {
+                  // Standby is enabled, and PRO has been held down for the required amount of time.
+                  State->Standby = 1;
+
+                  // While this isn't technically an alarm, it causes GOJAM just like all the rest
+                  TriggeredAlarm = 1;
+
+                  // Turn on the STBY light
+                  DskyChannel163 |= DSKY_STBY;
+                  ChannelOutput(State, 0163, DskyChannel163);
+                }
+              else
+                {
+                  // PRO was pressed for long enough to turn us back on. Let's get going!
+                  State->Standby = 0;
+
+                  // Turn off the STBY light
+                  DskyChannel163 &= ~DSKY_STBY;
+                  ChannelOutput(State, 0163, DskyChannel163);
+                }
+            }
+          if (!State->Standby && State->NightWatchman)
+            {
+              // NEWJOB wasn't checked before 0.64s elapsed. Sound the alarm!
+              TriggeredAlarm = 1;
+
+              // Set the NIGHT WATCHMAN bit in channel 77. Don't go through CpuWriteIO() because
+              // instructions writing to CH77 clear it. We'll broadcast changes to it in the
+              // generic alarm handler a bit further down.
+              State->InputChannel[077] |= CH77_NIGHT_WATCHMAN;
             }
         }
 
-      // Check alarms
-      if (02000 == (03777 & State->InputChannel[ChanSCALER1]))
+      // All the rest of this is switched off during standby.
+      if (!State->Standby)
         {
-          // The Night Watchman begins looking once every 1.28s...
-          State->NightWatchman = 1;
-        }
-      else if (State->NightWatchman && 00000 == (03777 & State->InputChannel[ChanSCALER1]))
-        {
-          // NEWJOB wasn't checked before 0.64s elapsed. Sound the alarm!
-          TriggeredAlarm = 1;
+          if (0400 == (0777 & State->InputChannel[ChanSCALER1]))
+            {
+              // The Rupt Lock alarm watches ISR state starting every 160ms
+              State->RuptLock = 1;
+              State->NoRupt = 1;
+            }
+          else if ((State->RuptLock || State->NoRupt) && 0300 == (0777 & State->InputChannel[ChanSCALER1]))
+            {
+              // We've either had no interrupts, or stuck in one, for 140ms. Sound the alarm!
+              TriggeredAlarm = 1;
 
-          // Set the NIGHT WATCHMAN bit in channel 77. Don't go through CpuWriteIO() because
-          // instructions writing to CH77 clear it. We'll broadcast changes to it in the
-          // generic alarm handler a bit further down.
-          State->InputChannel[077] |= CH77_NIGHT_WATCHMAN;
+              // Set the RUPT LOCK bit in channel 77.
+              State->InputChannel[077] |= CH77_RUPT_LOCK;
+            }
+
+          if (020 == (037 & State->InputChannel[ChanSCALER1]))
+            {
+              // The TC Trap alarm watches executing instructions every 5ms
+              State->TCTrap = 1;
+              State->NoTC = 1;
+            }
+          else if ((State->TCTrap || State->NoTC) && 000 == (037 & State->InputChannel[ChanSCALER1]))
+            {
+              // We've either executed no TC at all, or only TCs, for the past 5ms. Sound the alarm!
+              TriggeredAlarm = 1;
+
+              // Set the TC TRAP bit in channel 77.
+              State->InputChannel[077] |= CH77_TC_TRAP;
+            }
+
+          // Now that that's taken care of...
+          // If so, the 10 ms. timers TIME1 and TIME3 are updated.
+          // Recall that the registers are in AGC integer format,
+          // and therefore are actually shifted left one space.
+          // When taking a reset, the real AGC would skip unprogrammed
+          // sequences and go straight to GOJAM. The requests, however,
+          // would be saved and the counts would happen immediately
+          // after the first instruction at 4000, so doing them now
+          // is not too inaccurate.
+          if (0 == (037 & State->InputChannel[ChanSCALER1]))
+	    {
+	      State->ExtraDelay++;
+	      if (CounterPINC (&c(RegTIME1)))
+	        {
+	          State->ExtraDelay++;
+	          CounterPINC (&c(RegTIME2));
+	        }
+	      State->ExtraDelay++;
+	      if (CounterPINC (&c(RegTIME3)))
+	        State->InterruptRequests[3] = 1;
+	    }
+          // TIME5 is the same as TIME3, but 5 ms. out of phase.
+          if (020 == (037 & State->InputChannel[ChanSCALER1]))
+	    {
+	      State->ExtraDelay++;
+	      if (CounterPINC (&c(RegTIME5)))
+	        State->InterruptRequests[2] = 1;
+	    }
+          // TIME4 is the same as TIME3, but 7.5ms out of phase
+          if (030 == (037 & State->InputChannel[ChanSCALER1]))
+	    {
+	      State->ExtraDelay++;
+	      if (CounterPINC (&c(RegTIME4)))
+	        State->InterruptRequests[4] = 1;
+	    }
+          // TIME6 only increments when it has been enabled via CH13 bit 15.
+          // It increments 0.3125ms after TIME1/TIME3
+          if (040000 & State->InputChannel[013] && State->InputChannel[ChanSCALER1] == 1)
+            {
+              State->ExtraDelay++;
+              if (CounterDINC (State, 0, &c(RegTIME6)))
+                {
+	          State->InterruptRequests[1] = 1;
+                  // Triggering a T6RUPT disables T6 by clearing the CH13 bit
+                  CpuWriteIO(State, 013, State->InputChannel[013] & 037777);
+                }
+            }
         }
 
-      if (0200 == (0377 & State->InputChannel[ChanSCALER1]))
-        {
-          // The Rupt Lock alarm watches ISR state starting every 160ms
-          State->RuptLock = 1;
-          State->NoRupt = 1;
-        }
-      else if ((State->RuptLock || State->NoRupt) && 0140 == (0377 & State->InputChannel[ChanSCALER1]))
-        {
-          // We've either had no interrupts, or stuck in one, for 140ms. Sound the alarm!
-          TriggeredAlarm = 1;
-
-          // Set the RUPT LOCK bit in channel 77.
-          State->InputChannel[077] |= CH77_RUPT_LOCK;
-        }
-
-      if (010 == (017 & State->InputChannel[ChanSCALER1]))
-        {
-          // The TC Trap alarm watches executing instructions every 5ms
-          State->TCTrap = 1;
-          State->NoTC = 1;
-        }
-      else if ((State->TCTrap || State->NoTC) && 000 == (017 & State->InputChannel[ChanSCALER1]))
-        {
-          // We've either executed no TC at all, or only TCs, for the past 5ms. Sound the alarm!
-          TriggeredAlarm = 1;
-
-          // Set the TC TRAP bit in channel 77.
-          State->InputChannel[077] |= CH77_TC_TRAP;
-        }
 
       // If we triggered any alarms, simulate a GOJAM
       if (TriggeredAlarm)
@@ -1795,9 +1842,12 @@ agc_engine (agc_t * State)
               c(RegZ) = 04000;
               State->InIsr = 0;
 
-              // Light the RESTART light on the DSKY
-              DskyChannel163 |= DSKY_RESTART;
-              ChannelOutput(State, 0163, DskyChannel163);
+              // Light the RESTART light on the DSKY, if we're not going into standby
+              if (!State->Standby)
+                {
+                  DskyChannel163 |= DSKY_RESTART;
+                  ChannelOutput(State, 0163, DskyChannel163);
+                }
 
             }
 
@@ -1814,6 +1864,11 @@ agc_engine (agc_t * State)
           return (0);
         }
     }
+
+  // If we're in standby mode, this is all we can accomplish --
+  // everything else is switched off.
+  if (State->Standby)
+    return (0);
 
   //----------------------------------------------------------------------
   // Same principle as for the counter-timers (above), but for handling 

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -270,6 +270,10 @@
  *				how interrupt priorities are handled, and
  *				corrected ZRUPT to be return addr+1.
  *				Aurora 12 now passes all of SELFCHK in yaAGC.
+ *		10/04/16 MAS	Added support for standby mode, added the
+ *				standby light to the light test, and fixed
+ *				the speed of scaler counting and phasing of
+ *				TIME6.
  *
  *
  * The technical documentation for the Apollo Guidance & Navigation (G&N) system,

--- a/yaAGC/agc_engine.c
+++ b/yaAGC/agc_engine.c
@@ -1817,7 +1817,7 @@ agc_engine (agc_t * State)
 	    }
           // TIME6 only increments when it has been enabled via CH13 bit 15.
           // It increments 0.3125ms after TIME1/TIME3
-          if (040000 & State->InputChannel[013] && State->InputChannel[ChanSCALER1] == 1)
+          if (040000 & State->InputChannel[013] && (State->InputChannel[ChanSCALER1] & 01) == 01)
             {
               State->ExtraDelay++;
               if (CounterDINC (State, 0, &c(RegTIME6)))

--- a/yaAGC/agc_engine.h
+++ b/yaAGC/agc_engine.h
@@ -339,6 +339,8 @@ typedef struct
   unsigned NoRupt:1;            // Set when rupts are being watched. Cleared by executing any ISR instruction
   unsigned TCTrap:1;            // Set when TC is being watched. Cleared by executing any non-TC/TCF instruction
   unsigned NoTC:1;              // Set when TC is being watched. Cleared by executing TC or TCF
+  unsigned Standby:1;           // Set while the computer is in standby mode.
+  unsigned SbyPressed:1;        // Set while PRO is being held down; cleared by releasing PRO
   uint64_t /*unsigned long long */ DownruptTime;	// Time when next DOWNRUPT occurs.
   int Downlink;
   // The following pointer is present for whatever use the Orbiter

--- a/yaAGC/agc_engine_init.c
+++ b/yaAGC/agc_engine_init.c
@@ -247,6 +247,9 @@ agc_engine_init (agc_t * State, const char *RomImage, const char *CoreDump,
   State->TCTrap = 0;
   State->NoTC = 0;
 
+  State->Standby = 0;
+  State->SbyPressed = 0;
+
   if (CoreDump != NULL)
     {
       cd = fopen (CoreDump, "r");

--- a/yaDSKY2/yaDSKY2.cpp
+++ b/yaDSKY2/yaDSKY2.cpp
@@ -657,7 +657,7 @@ void MainFrame::on_ProButton_pressed(wxMouseEvent &event)
   else
     {
       // Press.
-      OutputPro (1);
+      OutputPro (0);
       ProceedPressed = true;
     }
   if (NumMatches)
@@ -707,7 +707,7 @@ void MainFrame::on_LeftMouse_released(wxMouseEvent &event)
 {
     if (ProceedPressed)
     {
-        OutputPro(0);
+        OutputPro(1);
         ProceedPressed = false;
     }
 }


### PR DESCRIPTION
The only things that operates in standby mode, for the moment, are the scalers and the DSKY. I found while doing this that the HI SCALER and LOW SCALER input channels were incrementing too slowly  -- LOW SCALER should increment at 3200pps, not 1600pps. Since those channels are how the AGC determines how much time elapsed in standby mode, time appeared to move at half speed while the computer was in standby. As a side bonus of speeding them up, TIME6 finally has the right phasing.

Here's a little gif of the light test and standby mode in action:
![yaagc_standby](https://cloud.githubusercontent.com/assets/94056/19101255/85c361bc-8a7b-11e6-872b-3b75f526d5f1.gif)
